### PR TITLE
DC-197 request entity too large error: use character-count textareas

### DIFF
--- a/server/views/formPages/categoriser/provisionalCategory.html
+++ b/server/views/formPages/categoriser/provisionalCategory.html
@@ -2,7 +2,7 @@
 
 {% from "warning-text/macro.njk" import govukWarningText %}
 {% from "radios/macro.njk" import govukRadios %}
-{% from "textarea/macro.njk" import govukTextarea %}
+{% from "character-count/macro.njk" import govukCharacterCount %}
 {% from "button/macro.njk" import govukButton %}
 
 {% set cat = data.suggestedCat %}
@@ -59,10 +59,12 @@
     {% endif %}
   {% endif %}
 
-  {{ govukTextarea({
+  {{ govukCharacterCount({
     name: "overriddenCategoryText",
     type: "myTextWhatsThisFor",
     id: "overriddenCategoryText",
+    maxlength: 50000,
+    threshold: 50,
     label: {
       text: "Explain why you changed the category"
     },

--- a/server/views/formPages/ratings/escapeRating.html
+++ b/server/views/formPages/ratings/escapeRating.html
@@ -3,7 +3,7 @@
 {% from "radios/macro.njk" import govukRadios %}
 
 {% from "warning-text/macro.njk" import govukWarningText %}
-{% from "textarea/macro.njk" import govukTextarea %}
+{% from "character-count/macro.njk" import govukCharacterCount %}
 
 {% macro renderAlert(alert) %}
   <p class="govuk-!-margin-bottom-1">{{ alert.alertCode }} {{ alert.comment }} <strong>{{ alert.dateCreated }}</strong>
@@ -36,10 +36,12 @@
 
 {% set escapeTextHtml %}
 
-{{ govukTextarea({
+{{ govukCharacterCount({
   name: "escapeFurtherChargesText",
   type: "escapeFurtherChargesText",
   id: "escapeFurtherChargesText",
+  maxlength: 50000,
+  threshold: 50,
   label: {
     text: "Provide details of these charges"
   },

--- a/server/views/formPages/ratings/extremismRating.html
+++ b/server/views/formPages/ratings/extremismRating.html
@@ -1,13 +1,15 @@
 {% extends "../formTemplate.html" %}
 {% from "warning-text/macro.njk" import govukWarningText %}
-{% from "textarea/macro.njk" import govukTextarea %}
+{% from "character-count/macro.njk" import govukCharacterCount %}
 {% from "radios/macro.njk" import govukRadios %}
 
 {% set previousTerrorismOffencesTextHtml %}
-  {{ govukTextarea({
+  {{ govukCharacterCount({
     name: "previousTerrorismOffencesText",
     type: "previousTerrorismOffencesText",
     id: "previousTerrorismOffencesText",
+    maxlength: 50000,
+    threshold: 50,
     label: {
       text: "Give details of this evidence"
     },

--- a/server/views/formPages/ratings/offendingHistory.html
+++ b/server/views/formPages/ratings/offendingHistory.html
@@ -1,7 +1,7 @@
 {% extends "../formTemplate.html" %}
 
 {% from "warning-text/macro.njk" import govukWarningText %}
-{% from "textarea/macro.njk" import govukTextarea %}
+{% from "character-count/macro.njk" import govukCharacterCount %}
 
 {% block formItems %}
 
@@ -23,10 +23,12 @@
     </div>
   {% endif %}
 
-  {{ govukTextarea({
+  {{ govukCharacterCount({
     name: "previousConvictions",
     type: "previousConvictions",
     id: "more-detail",
+    maxlength: 50000,
+    threshold: 50,
     label: {
       text: "Please record a summary of previous convictions, and any other information, from this offender's PNC record, which might be relevant to their categorisation"
     },

--- a/server/views/formPages/ratings/securityBack.html
+++ b/server/views/formPages/ratings/securityBack.html
@@ -2,7 +2,6 @@
 {% from "radios/macro.njk" import govukRadios %}
 {% from "inset-text/macro.njk" import govukInsetText %}
 {% from "warning-text/macro.njk" import govukWarningText %}
-{% from "textarea/macro.njk" import govukTextarea %}
 
 {% block formItems %}
 

--- a/server/views/formPages/ratings/securityInput.html
+++ b/server/views/formPages/ratings/securityInput.html
@@ -2,7 +2,7 @@
 {% from "radios/macro.njk" import govukRadios %}
 {% from "inset-text/macro.njk" import govukInsetText %}
 {% from "warning-text/macro.njk" import govukWarningText %}
-{% from "textarea/macro.njk" import govukTextarea %}
+{% from "character-count/macro.njk" import govukCharacterCount %}
 
 {% block formItems %}
 
@@ -11,10 +11,12 @@
 
 {% set securityInputTextHtml %}
 
-  {{ govukTextarea({
+  {{ govukCharacterCount({
     name: "securityInputNeededText",
     type: "securityInputText",
     id: "securityInputNeededText",
+    maxlength: 50000,
+    threshold: 50,
     label: {
     text: "Please explain why security input is needed"
     },

--- a/server/views/formPages/ratings/violenceRating.html
+++ b/server/views/formPages/ratings/violenceRating.html
@@ -1,13 +1,15 @@
 {% extends "../formTemplate.html" %}
 {% from "warning-text/macro.njk" import govukWarningText %}
-{% from "textarea/macro.njk" import govukTextarea %}
+{% from "character-count/macro.njk" import govukCharacterCount %}
 {% from "radios/macro.njk" import govukRadios %}
 
 {% set highRiskOfViolenceTextHtml %}
-  {{ govukTextarea({
+  {{ govukCharacterCount({
     name: "highRiskOfViolenceText",
     type: "highRiskOfViolenceText",
     id: "highRiskOfViolenceText",
+    maxlength: 50000,
+    threshold: 50,
     label: {
       text: "Give details of this evidence"
     },
@@ -19,10 +21,12 @@
 {% endset %}
 
 {% set seriousThreatTextHtml %}
-  {{ govukTextarea({
+  {{ govukCharacterCount({
     name: "seriousThreatText",
     type: "seriousThreatText",
     id: "seriousThreatText",
+    maxlength: 50000,
+    threshold: 50,
     label: {
       text: "Give details of this evidence"
     },

--- a/server/views/formPages/security/review.html
+++ b/server/views/formPages/security/review.html
@@ -4,7 +4,7 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "error-summary/macro.njk" import govukErrorSummary %}
 {% from "panel/macro.njk" import govukPanel %}
-{% from "textarea/macro.njk" import govukTextarea %}
+{% from "character-count/macro.njk" import govukCharacterCount %}
 
 {% block beforeContent %}
 
@@ -42,10 +42,12 @@
 
     <h1 class="govuk-heading-l">Security Review</h1>
 
-    {{ govukTextarea({
+    {{ govukCharacterCount({
       name: "securityReview",
       type: "securityReview",
       id: "more-detail",
+      maxlength: 50000,
+      threshold: 50,
       label: {
         text: "Please provide an assessment of any Security information held on this prisoner, which could be relevant to their security categorisation"
       },

--- a/server/views/formPages/supervisor/review.html
+++ b/server/views/formPages/supervisor/review.html
@@ -1,6 +1,6 @@
 {% extends "../formTemplate.html" %}
 {% from "warning-text/macro.njk" import govukWarningText %}
-{% from "textarea/macro.njk" import govukTextarea %}
+{% from "character-count/macro.njk" import govukCharacterCount %}
 {% from "button/macro.njk" import govukButton %}
 {% from "radios/macro.njk" import govukRadios %}
 
@@ -101,10 +101,12 @@
         {% endif %}
       {% endif %}
 
-      {{ govukTextarea({
+      {{ govukCharacterCount({
         name: "supervisorOverriddenCategoryText",
         type: "myTextWhatsThisFor",
         id: "supervisorOverriddenCategoryText",
+        maxlength: 50000,
+        threshold: 50,
         label: {
           text: "Explain why you changed the category"
         },


### PR DESCRIPTION
This PR just alerts the user when the textarea contains too much text. Ive set a limit of 50000 chars, with a count displayed when the contents goes over 50% of this.

The user can still post the form though (and if over about 80K the 'request entity too large' error will still occur), so not a complete solution.