### PR TITLE
DC-207 The client api secret does not appear to be escaped

### DIFF
--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/mockapis/OauthApi.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/mockapis/OauthApi.groovy
@@ -18,7 +18,7 @@ class OauthApi extends WireMockRule {
     final accessToken = JwtFactory.token(user.username, user.roles)
 
     this.stubFor(
-      get(urlMatching('/auth/oauth/authorize\\?response_type=code&redirect_uri=.+&state=.+&client_id=licences'))
+      get(urlMatching('/auth/oauth/authorize\\?response_type=code&redirect_uri=.+&state=.+&client_id=categorisationtool'))
         .willReturn(aResponse().withBody('<html><body>Login page<h1>Sign in</h1></body></html>')
         .withHeader('Location', "http://localhost:3000/login/callback?code=codexxxx&state=stateyyyy")
         // .withTransformers("response-template")

--- a/server/authentication/clientCredentials.js
+++ b/server/authentication/clientCredentials.js
@@ -1,5 +1,4 @@
 const config = require('../config')
-const querystring = require('querystring')
 
 module.exports = {
   generateOauthClientToken,
@@ -13,6 +12,6 @@ function generateOauthClientToken(
 }
 
 function generate(clientId, clientSecret) {
-  const token = Buffer.from(`${querystring.escape(clientId)}:${querystring.escape(clientSecret)}`).toString('base64')
+  const token = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
   return `Basic ${token}`
 }

--- a/server/config.js
+++ b/server/config.js
@@ -36,7 +36,7 @@ module.exports = {
         response: 30000,
         deadline: 35000,
       },
-      apiClientId: get('API_CLIENT_ID', 'licences', true),
+      apiClientId: get('API_CLIENT_ID', 'categorisationtool', true),
       apiClientSecret: get('API_CLIENT_SECRET', 'clientsecret'),
     },
     elite2: {


### PR DESCRIPTION
Actually it *was* escaped, but should not have been. Fixed in the same manner as NN etc.
Also switched from licences default client id to categorisationtool for in-memory use