### PR TITLE
Cat_425 new agency agnostic endpoint for u21 lookups

### DIFF
--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/mockapis/Elite2Api.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/mockapis/Elite2Api.groovy
@@ -259,27 +259,23 @@ class Elite2Api extends WireMockRule {
     )
 
     this.stubFor(
-      post("/api/offender-assessments/category/LEI?latestOnly=true")
+      post("/api/offender-assessments/CATEGORY?latestOnly=true&activeOnly=false")
         .willReturn(
         aResponse()
           .withBody(JsonOutput.toJson([
           [
             bookingId     : 21,
             offenderNo    : 'C0001AA',
-            firstName     : 'TINY',
-            lastName      : 'TIM',
-            category      : 'C',
+            classificationCode      : 'C',
             nextReviewDate: '2019-07-25',
-            assessStatus: assessStatusList[2]
+            assessmentStatus: assessStatusList[2]
           ],
           [
             bookingId     : 22,
             offenderNo    : 'C0002AA',
-            firstName     : 'ADRIAN',
-            lastName      : 'MOLE',
-            category      : 'D',
+            classificationCode      : 'D',
             nextReviewDate: '2019-07-27',
-            assessStatus  : assessStatusList[3]
+            assessmentStatus  : assessStatusList[3]
           ],
         ]
         ))
@@ -347,27 +343,23 @@ class Elite2Api extends WireMockRule {
     )
 
     this.stubFor(
-      post("/api/offender-assessments/category/LEI?latestOnly=true")
+      post("/api/offender-assessments/CATEGORY?latestOnly=true&activeOnly=false")
         .willReturn(
         aResponse()
           .withBody(JsonOutput.toJson([
           [
             bookingId     : 21,
             offenderNo    : 'C0001AA',
-            firstName     : 'TINY',
-            lastName      : 'TIM',
-            category      : 'C',
+            classificationCode      : 'C',
             nextReviewDate: '2019-07-25',
-            assessStatus: 'A'
+            assessmentStatus: 'A'
           ],
           [
             bookingId     : 22,
             offenderNo    : 'C0002AA',
-            firstName     : 'ADRIAN',
-            lastName      : 'MOLE',
-            category      : 'D',
+            classificationCode      : 'D',
             nextReviewDate: '2019-07-27',
-            assessStatus  : 'A'
+            assessmentStatus  : 'A'
           ],
         ]
         ))
@@ -1060,7 +1052,7 @@ class Elite2Api extends WireMockRule {
   def stubAgencyDetails(agency) {
 
     this.stubFor(
-      get("/api/agencies/$agency")
+      get("/api/agencies/$agency?activeOnly=false")
         .willReturn(
           aResponse()
             .withBody(JsonOutput.toJson([

--- a/server/data/nomisClientBuilder.js
+++ b/server/data/nomisClientBuilder.js
@@ -25,9 +25,9 @@ module.exports = token => {
       const path = `${apiUrl}api/offender-assessments/category/${agencyId}?latestOnly=false`
       return nomisPost({ path, body: bookingIds })
     },
-    getLatestCategorisationForOffenders(agencyId, bookingIds) {
-      const path = `${apiUrl}api/offender-assessments/category/${agencyId}?latestOnly=true`
-      return nomisPost({ path, body: bookingIds })
+    getLatestCategorisationForOffenders(agencyId, offenderNos) {
+      const path = `${apiUrl}api/offender-assessments/CATEGORY?latestOnly=true&activeOnly=false`
+      return nomisPost({ path, body: offenderNos })
     },
     getRecategoriseOffenders(agencyId, cutoff) {
       const path = `${apiUrl}api/offender-assessments/category/${agencyId}?type=RECATEGORISATIONS&date=${cutoff}`
@@ -35,7 +35,8 @@ module.exports = token => {
     },
     getPrisonersAtLocation(agencyId, fromDob, toDob) {
       const path = `${apiUrl}api/locations/description/${agencyId}/inmates?fromDob=${fromDob}&toDob=${toDob}&returnCategory=true`
-      return nomisUserGet({ path })
+      const headers = { 'Page-Limit': 5000 }
+      return nomisUserGet({ path, headers })
     },
     getSentenceDatesForOffenders(bookingIds) {
       const path = `${apiUrl}api/offender-sentences/bookings`
@@ -90,7 +91,7 @@ module.exports = token => {
       return nomisUserGet({ path })
     },
     getAgencyDetail(agencyId) {
-      const path = `${apiUrl}api/agencies/${agencyId}`
+      const path = `${apiUrl}api/agencies/${agencyId}?activeOnly=false`
       return nomisUserGet({ path })
     },
     createSupervisorApproval(details) {

--- a/test/data/nomisClient.test.js
+++ b/test/data/nomisClient.test.js
@@ -43,7 +43,7 @@ describe('nomisClient', () => {
   describe('getAgencyDetail', () => {
     it('should construct an api call', async () => {
       const agencyResponse = { description: 'Moorlands' }
-      fakeElite2Api.get(`/api/agencies/LEI`).reply(200, agencyResponse)
+      fakeElite2Api.get(`/api/agencies/LEI?activeOnly=false`).reply(200, agencyResponse)
 
       const output = await nomisClient.getAgencyDetail('LEI')
       return expect(output).toEqual(agencyResponse)

--- a/test/services/offenderService.test.js
+++ b/test/services/offenderService.test.js
@@ -1261,18 +1261,27 @@ describe('getMatchedCategorisations', () => {
           bookingId: 10,
           firstName: 'Jane',
         },
+        {
+          bookingId: 12,
+          firstName: 'Inactive',
+        },
       ]
 
       const eliteU21Cats = [
         {
           offenderNo: 'B1234AA',
           bookingId: 10,
-          assessStatus: 'A',
+          assessmentStatus: 'A',
+        },
+        {
+          offenderNo: 'B1234AA',
+          bookingId: 12,
+          assessmentStatus: 'I',
         },
         {
           offenderNo: 'B1234AB',
           bookingId: 11,
-          assessStatus: 'P',
+          assessmentStatus: 'P',
         },
       ]
 
@@ -1287,6 +1296,10 @@ describe('getMatchedCategorisations', () => {
           bookingId: 10,
           firstName: 'Jane',
           assessStatus: 'A',
+        },
+        {
+          bookingId: 12,
+          firstName: 'Inactive', // an inactive cat was returned here
         },
       ]
       nomisClient.getLatestCategorisationForOffenders.mockReturnValue(eliteU21Cats)


### PR DESCRIPTION
overriding page limit for initial u21 query
added flag to prevent 404 when prison is inactive