### PR TITLE
CAT-508 Cat A warning bug

### DIFF
--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/ratings/OffendingHistorySpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/ratings/OffendingHistorySpecification.groovy
@@ -68,7 +68,6 @@ class OffendingHistorySpecification extends GebReportingSpec {
     db.getData(12).status == ["STARTED"]
   }
 
-
   def "The Offending history page is shown correctly (no previous cat A)"() {
     when: 'I go to the Offending history page'
 

--- a/server/routes/form.js
+++ b/server/routes/form.js
@@ -51,7 +51,11 @@ module.exports = function Index({
       const form = 'offendingHistory'
       const { bookingId } = req.params
       const result = await buildFormData(res, req, section, form, bookingId, transactionalDbClient)
-      const history = await offendersService.getCatAInformation(res.locals.user.token, result.data.details.offenderNo)
+      const history = await offendersService.getCatAInformation(
+        res.locals.user.token,
+        result.data.details.offenderNo,
+        bookingId
+      )
       const offences = await offendersService.getOffenceHistory(res.locals.user.token, result.data.details.offenderNo)
       const data = { ...result.data, history, offences }
       res.render(`formPages/${section}/${form}`, { ...result, data })
@@ -145,7 +149,11 @@ module.exports = function Index({
       const { bookingId } = req.params
       const result = await buildFormData(res, req, 'categoriser', 'review', bookingId, transactionalDbClient)
 
-      const history = await offendersService.getCatAInformation(res.locals.user.token, result.data.details.offenderNo)
+      const history = await offendersService.getCatAInformation(
+        res.locals.user.token,
+        result.data.details.offenderNo,
+        bookingId
+      )
       const offences = await offendersService.getOffenceHistory(res.locals.user.token, result.data.details.offenderNo)
 
       const escapeProfile = await riskProfilerService.getEscapeProfile(

--- a/server/views/partials/warningOffendingHistory.html
+++ b/server/views/partials/warningOffendingHistory.html
@@ -2,18 +2,21 @@
 {% from "inset-text/macro.njk" import govukInsetText %}
 
 {% set warningText %}
+  This prisoner was categorised as a
   {% if data.history.catAType === 'A' %}
-    This prisoner was categorised as a Cat A in {{ data.history.catAStartYear }} until {{ data.history.catAEndYear }}
-    for a previous sentence and released as a {{ data.history.finalCat }} in {{ data.history.releaseYear }}
+    Cat A
   {% elif data.history.catAType === 'P' %}
-    This prisoner was treated as a Provisional Cat A in {{ data.history.catAStartYear }} until {{ data.history.catAEndYear }}
-    for a previous sentence and released as a {{ data.history.finalCat }} in {{ data.history.releaseYear }}
+    Provisional Cat A
   {% elif data.history.catAType === 'H' %}
-    This prisoner was categorised as a Cat A High in {{ data.history.catAStartYear }} until {{ data.history.catAEndYear }}
+    Cat A High
+  {% endif %}
+  in {{ data.history.catAStartYear }} until {{ data.history.catAEndYear }}
+
+  {% if data.history.releaseYear %}
     for a previous sentence and released as a {{ data.history.finalCat }} in {{ data.history.releaseYear }}
   {% endif %}
 {% endset %}
-{% if warningText | trim %}
+{% if data.history.catAType %}
 <div>
   <h2 class="govuk-heading-m">Previous categorisation</h2>
   {{ govukWarningText({

--- a/test/routes/recat.test.js
+++ b/test/routes/recat.test.js
@@ -50,7 +50,6 @@ const offendersService = {
   getUncategorisedOffenders: jest.fn(),
   getOffenderDetails: jest.fn(),
   getImage: jest.fn(),
-  getCatAInformation: jest.fn(),
   getOffenceHistory: jest.fn(),
   createSupervisorApproval: jest.fn(),
   createInitialCategorisation: jest.fn(),
@@ -84,7 +83,6 @@ beforeEach(() => {
   formService.categoriserDecision.mockReturnValue({})
   offendersService.createInitialCategorisation.mockReturnValue({ bookingId: 12345, seq: 4 })
   offendersService.getOffenderDetails.mockResolvedValue({ displayName: 'Claire Dent' })
-  offendersService.getCatAInformation.mockResolvedValue({})
   offendersService.getOffenceHistory.mockResolvedValue({})
   offendersService.getPrisonerBackground.mockResolvedValue({})
   userService.getUser.mockResolvedValue({})

--- a/test/routes/tasklistRecat.test.js
+++ b/test/routes/tasklistRecat.test.js
@@ -25,7 +25,6 @@ const offendersService = {
   getUncategorisedOffenders: jest.fn(),
   getOffenderDetails: jest.fn(),
   getImage: jest.fn(),
-  getCatAInformation: jest.fn(),
 }
 
 const userService = {

--- a/test/services/offenderServiceGetCatAInformation.test.js
+++ b/test/services/offenderServiceGetCatAInformation.test.js
@@ -24,18 +24,20 @@ describe('getCatAInformation', () => {
   test('it should return previous Cat A and sentence information', async () => {
     const categories = [
       {
-        bookingId: -45,
+        bookingId: 45,
         offenderNo,
         classificationCode: 'A',
         classification: 'Cat A',
         assessmentDate: '2012-04-04',
+        assessmentSeq: 2,
       },
       {
-        bookingId: -45,
+        bookingId: 45,
         offenderNo,
         classificationCode: 'B',
         classification: 'Cat B',
         assessmentDate: '2013-03-24',
+        assessmentSeq: 3,
       },
     ]
 
@@ -44,20 +46,20 @@ describe('getCatAInformation', () => {
         offenderNo,
         firstName: 'firstName',
         lastName: 'lastName',
-        sentenceDetail: { bookingId: -45, releaseDate: '2014-02-03' },
+        sentenceDetail: { bookingId: 45, releaseDate: '2014-02-03' },
       },
       {
         offenderNo,
         firstName: 'firstName',
         lastName: 'lastName',
-        sentenceDetail: { bookingId: -55, releaseDate: '2015-02-03' },
+        sentenceDetail: { bookingId: 55, releaseDate: '2015-02-03' },
       },
     ]
 
     nomisClient.getCategoryHistory.mockReturnValue(categories)
     nomisClient.getSentenceHistory.mockReturnValue(sentences)
 
-    const result = await service.getCatAInformation('token', offenderNo)
+    const result = await service.getCatAInformation('token', offenderNo, 55)
     expect(nomisClient.getCategoryHistory).toBeCalledTimes(1)
     expect(nomisClient.getSentenceHistory).toBeCalledTimes(1)
     expect(result).toEqual({
@@ -72,7 +74,7 @@ describe('getCatAInformation', () => {
   test('it should handle no previous', async () => {
     nomisClient.getCategoryHistory.mockReturnValue([])
 
-    const result = await service.getCatAInformation('token', offenderNo)
+    const result = await service.getCatAInformation('token', offenderNo, 0)
     expect(nomisClient.getCategoryHistory).toBeCalledTimes(1)
     expect(nomisClient.getSentenceHistory).not.toBeCalled()
     expect(result).toEqual(emptyResponse)
@@ -81,7 +83,7 @@ describe('getCatAInformation', () => {
   test('it should handle previous but no Cat A', async () => {
     const categories = [
       {
-        bookingId: -45,
+        bookingId: 45,
         offenderNo,
         classificationCode: 'B',
         classification: 'Cat B',
@@ -95,7 +97,7 @@ describe('getCatAInformation', () => {
 
     nomisClient.getCategoryHistory.mockReturnValue(categories)
 
-    const result = await service.getCatAInformation('token', offenderNo)
+    const result = await service.getCatAInformation('token', offenderNo, 45)
     expect(nomisClient.getCategoryHistory).toBeCalledTimes(1)
     expect(nomisClient.getSentenceHistory).not.toBeCalled()
     expect(result).toEqual(emptyResponse)
@@ -104,65 +106,68 @@ describe('getCatAInformation', () => {
   test('it should handle Cat A not the first cat', async () => {
     const categories = [
       {
-        bookingId: -45,
+        bookingId: 45,
         offenderNo,
         classificationCode: 'B',
         classification: 'Cat B',
         assessmentDate: '2013-03-24',
+        assessmentSeq: 2,
       },
       {
-        bookingId: -45,
+        bookingId: 45,
         offenderNo,
         classificationCode: 'A',
         classification: 'Cat A',
         assessmentDate: '2014-04-04',
+        assessmentSeq: 3,
       },
     ]
 
-    const sentences = [
-      {
-        offenderNo,
-        firstName: 'firstName',
-        lastName: 'lastName',
-        sentenceDetail: { bookingId: -45, releaseDate: '2015-02-03' },
-      },
-    ]
     nomisClient.getCategoryHistory.mockReturnValue(categories)
-    nomisClient.getSentenceHistory.mockReturnValue(sentences)
 
-    const result = await service.getCatAInformation('token', offenderNo)
+    const result = await service.getCatAInformation('token', offenderNo, 45)
     expect(nomisClient.getCategoryHistory).toBeCalledTimes(1)
-    expect(nomisClient.getSentenceHistory).toBeCalledTimes(1)
+    expect(nomisClient.getSentenceHistory).not.toBeCalled()
     expect(result).toEqual({
       catAType: 'A',
       catAStartYear: '2014',
-      catAEndYear: '2015',
-      releaseYear: '2015',
+      catAEndYear: null,
+      releaseYear: null,
       finalCat: 'Cat A',
     })
   })
+
   test('it should handle no sentence info', async () => {
     const categories = [
       {
-        bookingId: -45,
+        bookingId: 45,
         offenderNo,
         classificationCode: 'A',
         classification: 'Cat A',
         assessmentDate: '2012-04-04',
+        assessmentSeq: 3,
       },
       {
-        bookingId: -45,
+        bookingId: 45,
         offenderNo,
         classificationCode: 'B',
         classification: 'Cat B',
         assessmentDate: '2013-03-24',
+        assessmentSeq: 4,
+      },
+      {
+        bookingId: 55,
+        offenderNo,
+        classificationCode: 'C',
+        classification: 'Cat C',
+        assessmentDate: '2014-03-24',
       },
     ]
 
     nomisClient.getCategoryHistory.mockReturnValue(categories)
     nomisClient.getSentenceHistory.mockReturnValue([])
 
-    const result = await service.getCatAInformation('token', offenderNo)
+    const result = await service.getCatAInformation('token', offenderNo, 55)
     expect(nomisClient.getCategoryHistory).toBeCalledTimes(1)
     expect(nomisClient.getSentenceHistory).toBeCalledTimes(1)
     expect(result).toEqual({
@@ -174,42 +179,47 @@ describe('getCatAInformation', () => {
     })
   })
 
-  test('it should find correct Cat A and sentence information from a long list', async () => {
+  test('it should find correct Cat A and sentence information from a long unsorted list', async () => {
     const categories = [
       {
-        bookingId: -35,
-        offenderNo,
-        classificationCode: 'C',
-        classification: 'Cat C',
-        assessmentDate: '2010-04-04',
-      },
-      {
-        bookingId: -35,
-        offenderNo,
-        classificationCode: 'B',
-        classification: 'Cat B',
-        assessmentDate: '2011-03-24',
-      },
-      {
-        bookingId: -45,
-        offenderNo,
-        classificationCode: 'A',
-        classification: 'Cat A',
-        assessmentDate: '2012-04-04',
-      },
-      {
-        bookingId: -45,
-        offenderNo,
-        classificationCode: 'B',
-        classification: 'Cat B',
-        assessmentDate: '2013-03-24',
-      },
-      {
-        bookingId: -55,
+        bookingId: 55,
         offenderNo,
         classificationCode: 'D',
         classification: 'Cat D',
         assessmentDate: '2015-04-04',
+        assessmentSeq: 7,
+      },
+      {
+        bookingId: 35,
+        offenderNo,
+        classificationCode: 'C',
+        classification: 'Cat C',
+        assessmentDate: '2010-04-04',
+        assessmentSeq: 2,
+      },
+      {
+        bookingId: 45,
+        offenderNo,
+        classificationCode: 'B',
+        classification: 'Cat B',
+        assessmentDate: '2013-03-24',
+        assessmentSeq: 4,
+      },
+      {
+        bookingId: 35,
+        offenderNo,
+        classificationCode: 'B',
+        classification: 'Cat B',
+        assessmentDate: '2011-03-24',
+        assessmentSeq: 6,
+      },
+      {
+        bookingId: 45,
+        offenderNo,
+        classificationCode: 'A',
+        classification: 'Cat A',
+        assessmentDate: '2012-04-04',
+        assessmentSeq: 3,
       },
     ]
 
@@ -218,26 +228,26 @@ describe('getCatAInformation', () => {
         offenderNo,
         firstName: 'firstName',
         lastName: 'lastName',
-        sentenceDetail: { bookingId: -35, releaseDate: '2011-02-03' },
+        sentenceDetail: { bookingId: 35, releaseDate: '2011-02-03' },
       },
       {
         offenderNo,
         firstName: 'firstName',
         lastName: 'lastName',
-        sentenceDetail: { bookingId: -45, releaseDate: '2014-02-03' },
+        sentenceDetail: { bookingId: 45, releaseDate: '2014-02-03' },
       },
       {
         offenderNo,
         firstName: 'firstName',
         lastName: 'lastName',
-        sentenceDetail: { bookingId: -55, releaseDate: '2015-02-03' },
+        sentenceDetail: { bookingId: 55, releaseDate: '2015-02-03' },
       },
     ]
 
     nomisClient.getCategoryHistory.mockReturnValue(categories)
     nomisClient.getSentenceHistory.mockReturnValue(sentences)
 
-    const result = await service.getCatAInformation('token', offenderNo)
+    const result = await service.getCatAInformation('token', offenderNo, 55)
     expect(nomisClient.getCategoryHistory).toBeCalledTimes(1)
     expect(nomisClient.getSentenceHistory).toBeCalledTimes(1)
     expect(result).toEqual({
@@ -245,6 +255,100 @@ describe('getCatAInformation', () => {
       catAStartYear: '2012',
       catAEndYear: '2013',
       releaseYear: '2014',
+      finalCat: 'Cat B',
+    })
+  })
+
+  test('it should find last Cat A of several', async () => {
+    const categories = [
+      {
+        bookingId: 1,
+        offenderNo,
+        classificationCode: 'A',
+        classification: 'Cat A',
+        assessmentDate: '2010-04-04',
+        assessmentSeq: 7,
+      },
+      {
+        bookingId: 2,
+        offenderNo,
+        classificationCode: 'C',
+        classification: 'Cat C',
+        assessmentDate: '2011-04-04',
+        assessmentSeq: 2,
+      },
+      {
+        bookingId: 3,
+        offenderNo,
+        classificationCode: 'H',
+        classification: 'Cat A high',
+        assessmentDate: '2012-03-24',
+        assessmentSeq: 4,
+      },
+      {
+        bookingId: 3,
+        offenderNo,
+        classificationCode: 'B',
+        classification: 'Cat B',
+        assessmentDate: '2013-03-24',
+        assessmentSeq: 6,
+      },
+    ]
+
+    nomisClient.getCategoryHistory.mockReturnValue(categories)
+
+    const result = await service.getCatAInformation('token', offenderNo, 3)
+    expect(nomisClient.getCategoryHistory).toBeCalledTimes(1)
+    expect(nomisClient.getSentenceHistory).not.toBeCalled()
+    expect(result).toEqual({
+      catAType: 'H',
+      catAStartYear: '2012',
+      catAEndYear: '2013',
+      releaseYear: null,
+      finalCat: 'Cat B',
+    })
+  })
+
+  test('it should omit release when cat A is in current sentence', async () => {
+    const categories = [
+      {
+        bookingId: 35,
+        offenderNo,
+        classificationCode: 'A',
+        classification: 'Cat A',
+        assessmentDate: '2010-04-04',
+        assessmentSeq: 3,
+      },
+      {
+        bookingId: 35,
+        offenderNo,
+        classificationCode: 'B',
+        classification: 'Cat B',
+        assessmentDate: '2011-03-24',
+        assessmentSeq: 6,
+      },
+    ]
+
+    const sentences = [
+      {
+        offenderNo,
+        firstName: 'firstName',
+        lastName: 'lastName',
+        sentenceDetail: { bookingId: 35, releaseDate: '2011-02-03' },
+      },
+    ]
+
+    nomisClient.getCategoryHistory.mockReturnValue(categories)
+    nomisClient.getSentenceHistory.mockReturnValue(sentences)
+
+    const result = await service.getCatAInformation('token', offenderNo, 35)
+    expect(nomisClient.getCategoryHistory).toBeCalledTimes(1)
+    expect(nomisClient.getSentenceHistory).not.toBeCalled()
+    expect(result).toEqual({
+      catAType: 'A',
+      catAStartYear: '2010',
+      catAEndYear: '2011',
+      releaseYear: null,
       finalCat: 'Cat B',
     })
   })


### PR DESCRIPTION
Fixed assuming a cat A could not occur during the current sentence, and also applied ordering (as endpoint cat history data is actually not ordered! )