### PR TITLE
CAT-609 Transaction incorrect order causes inconsistency during approve

### DIFF
--- a/server/routes/form.js
+++ b/server/routes/form.js
@@ -632,8 +632,6 @@ module.exports = function Index({
           formName: form,
           transactionalClient: transactionalDbClient,
         })
-        await offendersService.createSupervisorApproval(res.locals, bookingId, userInput)
-
         const categorisationRecord = await formService.getCategorisationRecord(bookingId, transactionalDbClient)
 
         if (userInput.catType === CatType.RECAT.name) {
@@ -647,6 +645,8 @@ module.exports = function Index({
 
           await formService.mergeRiskProfileData(bookingId, dataToStore, transactionalDbClient)
         }
+
+        await offendersService.createSupervisorApproval(res.locals, bookingId, userInput)
 
         const nextPath = getPathFor({ data: req.body, config: formPageConfig })
         res.redirect(`${nextPath}${bookingId}`)

--- a/server/services/offendersService.js
+++ b/server/services/offendersService.js
@@ -878,6 +878,11 @@ module.exports = function createOffendersService(nomisClientBuilder, formService
     const catRecords = await formService.getHistoricalCategorisationRecords(details.offenderNo, transactionalDbClient)
     const nomisRecords = await getAllApprovedCategorisationsForOffender(nomisClient, details.offenderNo)
 
+    const uniqueAgencies = [...new Set(nomisRecords.map(o => o.assessmentAgencyId))]
+    const agencyMap = new Map(
+      await Promise.all(uniqueAgencies.map(async a => [a, await getOptionalAssessmentAgencyDescription(context, a)]))
+    )
+
     const dataDecorated = await Promise.all(
       nomisRecords.map(async nomisRecord => {
         const foundCatRecord = catRecords.find(
@@ -885,7 +890,7 @@ module.exports = function createOffendersService(nomisClientBuilder, formService
         )
         return {
           ...nomisRecord,
-          prisonDescription: await getOptionalAssessmentAgencyDescription(context, nomisRecord.assessmentAgencyId),
+          prisonDescription: agencyMap.get(nomisRecord.assessmentAgencyId),
           recordExists: !!foundCatRecord,
           approvalDateDisplay: dateConverter(nomisRecord.approvalDate),
           sequence: foundCatRecord && foundCatRecord.sequence,

--- a/server/services/offendersService.js
+++ b/server/services/offendersService.js
@@ -838,9 +838,14 @@ module.exports = function createOffendersService(nomisClientBuilder, formService
         ? currentCats.filter(o => !o.approvalDate || moment(o.approvalDate, 'YYYY-MM-DD') <= approvalDate)
         : currentCats
 
+      const uniqueAgencies = [...new Set(filteredCats.map(o => o.assessmentAgencyId))]
+      const agencyMap = new Map(
+        await Promise.all(uniqueAgencies.map(async a => [a, await getOptionalAssessmentAgencyDescription(context, a)]))
+      )
+
       const decoratedCats = await Promise.all(
         filteredCats.map(async o => {
-          const description = await getOptionalAssessmentAgencyDescription(context, o.assessmentAgencyId)
+          const description = agencyMap.get(o.assessmentAgencyId)
           return {
             ...o,
             agencyDescription: description,

--- a/test/services/offenderService.test.js
+++ b/test/services/offenderService.test.js
@@ -1663,7 +1663,7 @@ describe('getCategorisationHistory', () => {
 
     const result = await service.getCategoryHistory(context, -45, mockTransactionalClient)
 
-    expect(nomisClient.getAgencyDetail).toBeCalledTimes(4)
+    expect(nomisClient.getAgencyDetail).toBeCalledTimes(3) // once per unique agency
     expect(nomisClient.getCategoryHistory).toBeCalledTimes(1)
     expect(result.history).toMatchObject(expected)
   })

--- a/test/services/offenderService.test.js
+++ b/test/services/offenderService.test.js
@@ -1443,7 +1443,7 @@ describe('getPrisonerBackground', () => {
 
     const result = await service.getPrisonerBackground(context, 'ABC1', moment('2019-04-16'))
 
-    expect(nomisClient.getAgencyDetail).toBeCalledTimes(3)
+    expect(nomisClient.getAgencyDetail).toBeCalledTimes(2) // 1 for each unique agency
     expect(nomisClient.getCategoryHistory).toBeCalledTimes(1)
     expect(result).toMatchObject(expected)
   })
@@ -1503,7 +1503,7 @@ describe('getPrisonerBackground', () => {
 
     const result = await service.getPrisonerBackground(context, 'ABC1')
 
-    expect(nomisClient.getAgencyDetail).toBeCalledTimes(4)
+    expect(nomisClient.getAgencyDetail).toBeCalledTimes(3)
     expect(nomisClient.getCategoryHistory).toBeCalledTimes(1)
     expect(result).toMatchObject(expected)
   })


### PR DESCRIPTION
Also filter duplicate agencies from the get-description calls